### PR TITLE
Fix duplicate jsx attribute error

### DIFF
--- a/src/app/pdf-editor/PDFEditorContent.tsx
+++ b/src/app/pdf-editor/PDFEditorContent.tsx
@@ -4801,6 +4801,12 @@ export const PDFEditorContent: React.FC = () => {
       const shape = element.element as ShapeType;
       const isInSelectionPreview = elementsInSelectionPreview.has(shape.id);
 
+      const isMultiSelected = editorState.multiSelection.selectedElements.some(
+        (el) => el.id === shape.id
+      );
+      const selectedElementIds =
+        editorState.multiSelection.selectedElements.map((el) => el.id);
+
       return (
         <MemoizedShape
           key={shape.id}
@@ -4813,8 +4819,16 @@ export const PDFEditorContent: React.FC = () => {
           onSelect={handleShapeSelect}
           onUpdate={updateShapeWithUndo}
           onDelete={(id) => handleDeleteShapeWithUndo(id, actualTargetView)}
+          // Multi-selection props
+          isMultiSelected={isMultiSelected}
+          selectedElementIds={selectedElementIds}
+          onMultiSelectDragStart={handleMultiSelectDragStart}
+          onMultiSelectDrag={handleMultiSelectDrag}
+          onMultiSelectDragStop={handleMultiSelectDragStop}
           // Selection preview prop
           isInSelectionPreview={isInSelectionPreview}
+          // Element index for z-index ordering
+          elementIndex={element.zIndex}
           // Transform-based drag offset for performance
           dragOffset={editorState.multiSelection.isDragging 
             ? editorState.multiSelection.dragOffsets[shape.id] || null 
@@ -4824,6 +4838,11 @@ export const PDFEditorContent: React.FC = () => {
     } else if (element.type === "image") {
       const image = element.element as ImageType;
       const isInSelectionPreview = elementsInSelectionPreview.has(image.id);
+      const isMultiSelected = editorState.multiSelection.selectedElements.some(
+        (el) => el.id === image.id
+      );
+      const selectedElementIds =
+        editorState.multiSelection.selectedElements.map((el) => el.id);
 
       return (
         <MemoizedImage
@@ -4837,8 +4856,16 @@ export const PDFEditorContent: React.FC = () => {
           onSelect={handleImageSelect}
           onUpdate={updateImage}
           onDelete={(id) => handleDeleteImageWithUndo(id, actualTargetView)}
+          // Multi-selection props
+          isMultiSelected={isMultiSelected}
+          selectedElementIds={selectedElementIds}
+          onMultiSelectDragStart={handleMultiSelectDragStart}
+          onMultiSelectDrag={handleMultiSelectDrag}
+          onMultiSelectDragStop={handleMultiSelectDragStop}
           // Selection preview prop
           isInSelectionPreview={isInSelectionPreview}
+          // Element index for z-index ordering
+          elementIndex={element.zIndex}
           // Transform-based drag offset for performance
           dragOffset={editorState.multiSelection.isDragging 
             ? editorState.multiSelection.dragOffsets[image.id] || null 


### PR DESCRIPTION
Add missing multi-selection and z-index props to `MemoizedShape` and `MemoizedImage` to resolve duplicate JSX attribute errors.

The error occurred because `MemoizedShape` and `MemoizedImage` were not receiving the same multi-selection and z-index related props as `MemoizedTextBox`, leading to inconsistencies and duplicate attribute issues when React tried to render them.

---
<a href="https://cursor.com/background-agent?bcId=bc-68dd437a-8893-423a-843a-0181204fb92e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68dd437a-8893-423a-843a-0181204fb92e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

